### PR TITLE
Python 3 compatibility

### DIFF
--- a/matlab_wrapper/__init__.py
+++ b/matlab_wrapper/__init__.py
@@ -20,6 +20,7 @@
 
 
 from __future__ import division, print_function, absolute_import
+from __future__ import unicode_literals
 
 __version__ = "0.9.3"
 

--- a/matlab_wrapper/matlab_session.py
+++ b/matlab_wrapper/matlab_session.py
@@ -20,6 +20,12 @@
 
 
 from __future__ import print_function, division, absolute_import
+from __future__ import unicode_literals
+
+__author__ = "Marek Rudnicki"
+__copyright__ = "Copyright 2014, Marek Rudnicki"
+__license__ = "GPLv3+"
+
 
 import numpy as np
 import platform
@@ -335,7 +341,7 @@ def load_engine_and_libs(matlab_root, options):
 
     ### Check MATLAB version
     try:
-        version_str = c_char_p.in_dll(libeng, "libeng_version").value
+        version_str = c_char_p.in_dll(libeng, "libeng_version").value.decode('ascii')
         version = tuple([int(v) for v in version_str.split('.')[:2]])
 
     except ValueError:
@@ -783,7 +789,7 @@ class Library(object):
 
         if 'libeng' in name:
 
-            self.engOpen.argtypes = (c_char_p,)
+            self.engOpen.argtypes = (ToCCharP,)
             self.engOpen.restype = POINTER(Engine)
             self.engOpen.errcheck = error_check
 
@@ -866,7 +872,7 @@ class Library(object):
             self.mxCreateStructArray.errcheck = error_check
 
             self.mxArrayToString.argtypes = (POINTER(mxArray),)
-            self.mxArrayToString.restype = c_char_p
+            self.mxArrayToString.restype = FromCCharP
             self.mxArrayToString.errcheck = error_check
 
             self.mxCreateString.argtypes = (c_char_p,)
@@ -907,3 +913,20 @@ class Library(object):
             out = getattr(self._lib, attr)
 
         return out
+
+
+
+class FromCCharP(object):
+    def __init__(self):
+        raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class ToCCharP(object):
+    def __init__(self):
+        raise NotImplementedError
+
+    def from_param(self, obj):
+        raise NotImplementedError

--- a/matlab_wrapper/matlab_session.py
+++ b/matlab_wrapper/matlab_session.py
@@ -50,6 +50,9 @@ class Engine(ctypes.Structure):
 mwSize = c_size_t
 mwIndex = c_size_t
 
+# Use the system's default encoding for en-/decoding strings 
+import sys
+encd_str = sys.getdefaultencoding()
 
 wrap_script = r"""
 ERRSTR__ = '';
@@ -157,7 +160,7 @@ class MatlabSession(object):
         if self._output_buffer is None:
             raise RuntimeError("Output buffer was not initialized properly.")
         else:
-            return self._output_buffer.value.decode('ascii')
+            return self._output_buffer.value.decode(encd_str)
 
 
 
@@ -537,7 +540,7 @@ def mxarray_to_ndarray(libmx, pm):
     dims = libmx.mxGetDimensions(pm)
     numelems = libmx.mxGetNumberOfElements(pm)
     elem_size = libmx.mxGetElementSize(pm)
-    class_name = libmx.mxGetClassName(pm)
+    class_name = libmx.mxGetClassName(pm).decode('ascii')
     is_numeric = libmx.mxIsNumeric(pm)
     is_complex = libmx.mxIsComplex(pm)
     data = libmx.mxGetData(pm)
@@ -685,7 +688,7 @@ def ndarray_to_mxarray(libmx, arr):
 
     ### Prepare `arr` object (convert to ndarray if possible), assert
     ### data type
-    if isinstance(arr, str) or isinstance(arr, unicode):
+    if isinstance(arr, str):
         pass
 
     elif isinstance(arr, dict):
@@ -706,15 +709,9 @@ def ndarray_to_mxarray(libmx, arr):
     else:
         raise NotImplementedError("Data type not supported: {}".format(type(arr)))
 
-
-
-
     ### Convert ndarray to mxarray
     if isinstance(arr, str):
         pm = libmx.mxCreateString(arr)
-
-    elif isinstance(arr, unicode):
-        pm = libmx.mxCreateString(arr.encode('utf-8'))
 
     elif isinstance(arr, np.ndarray) and arr.dtype.kind in ['i','u','f','c']:
         dim = arr.ctypes.shape_as(mwSize)
@@ -762,7 +759,7 @@ def ndarray_to_mxarray(libmx, arr):
 
         name_num = len(arr.dtype.names)
 
-        names_p = (c_char_p*name_num)(*[c_char_p(name) for name in arr.dtype.names])
+        names_p = (c_char_p*name_num)(*[c_char_p(name.encode('ascii')) for name in arr.dtype.names])
 
         pm = libmx.mxCreateStructArray(
             arr.ndim,
@@ -940,7 +937,7 @@ class CCharP_To_Unicode(object):
         pass
 
     def __call__(self, ccharp):
-        u = c_char_p(ccharp).value.decode('ascii')
+        u = c_char_p(ccharp).value.decode(encd_str)
         return u
 
 
@@ -949,5 +946,5 @@ class Unicode_To_CCharP(object):
         pass
 
     def from_param(self, unicode_str):
-        ccharp = c_char_p(unicode_str.encode('ascii'))
+        ccharp = c_char_p(unicode_str.encode(encd_str))
         return ccharp

--- a/matlab_wrapper/matlab_session.py
+++ b/matlab_wrapper/matlab_session.py
@@ -18,9 +18,16 @@
 # You should have received a copy of the GNU General Public License
 # along with matlab_wrapper.  If not, see <http://www.gnu.org/licenses/>.
 
-
+#Python 2.x compability
 from __future__ import print_function, division, absolute_import
 from __future__ import unicode_literals
+
+import six
+from six import string_types
+
+if six.PY2:
+    from future_builtins import zip
+
 
 __author__ = "Marek Rudnicki"
 __copyright__ = "Copyright 2014, Marek Rudnicki"
@@ -52,7 +59,7 @@ mwIndex = c_size_t
 
 # Use the system's default encoding for en-/decoding strings 
 import sys
-encd_str = sys.getdefaultencoding()
+encd_str = 'utf-8'
 
 wrap_script = r"""
 ERRSTR__ = '';
@@ -578,14 +585,7 @@ def mxarray_to_ndarray(libmx, pm):
 
 
     elif class_name == 'char':
-        # datasize = numelems + 1
-
-        # pystring = ctypes.create_string_buffer(datasize+1)
-        # libmx.mxGetString(pm, pystring, datasize)
-
-        # out = pystring.value.decode('ascii')
-
-        out = libmx.mxArrayToString(pm)
+        out= libmx.mxArrayToString(pm)
 
 
     elif class_name == 'logical':
@@ -688,7 +688,7 @@ def ndarray_to_mxarray(libmx, arr):
 
     ### Prepare `arr` object (convert to ndarray if possible), assert
     ### data type
-    if isinstance(arr, str):
+    if isinstance(arr, string_types):
         pass
 
     elif isinstance(arr, dict):
@@ -710,7 +710,7 @@ def ndarray_to_mxarray(libmx, arr):
         raise NotImplementedError("Data type not supported: {}".format(type(arr)))
 
     ### Convert ndarray to mxarray
-    if isinstance(arr, str):
+    if isinstance(arr, string_types):
         pm = libmx.mxCreateString(arr)
 
     elif isinstance(arr, np.ndarray) and arr.dtype.kind in ['i','u','f','c']:

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -178,7 +178,7 @@ def test_put_unicode(matlab):
 
     output = matlab.output_buffer.split()
 
-    s = output[-1].decode('utf-8')
+    s = output[-1]
 
     assert_equal(s, u"Łódź")
 

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -6,6 +6,7 @@
 """
 
 from __future__ import division, absolute_import, print_function
+from __future__ import unicode_literals
 
 __author__ = "Marek Rudnicki"
 

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -13,6 +13,7 @@ __author__ = "Marek Rudnicki"
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import pandas as pd
+import six
 
 import matlab_wrapper
 
@@ -399,7 +400,7 @@ def test_get_struct(matlab):
     desired = np.array([
         (1, 'a'),
         (2*1j, 'b')
-    ], dtype=[('x', 'complex'), ('y', 'S1')])
+    ], dtype=[('x', np.complex_), ('y', six.text_type)])
 
     assert_equal(s, desired)
 
@@ -509,7 +510,7 @@ def test_put_get_dataframe(matlab):
     desired = np.array([
         (0, 1.0, 2, 'asdf'),
         (1, 1.1, 4, 'marek')
-    ], dtype=[('index', '<i8'), ('a', '<f8'), ('b', '<i8'), ('c', 'S5')])
+    ], dtype=[('index', '<i8'), ('a', '<f8'), ('b', '<i8'), ('c', six.text_type)])
 
     assert_equal(a, desired)
 


### PR DESCRIPTION
Using six and UTF-8 as default encodign for strings, I got python 3 support running without loosing support for python 2.

Tested using the test_matlab.py:
4 tests fail using python 2.7, linux:
 - test_put_get_series, test_put_get_dataframe, test_get_uninitialized_struct, test_get_struct: "TypeError: data type not understood" when trying to create expected(!) array. Maybe somethings wrong with my python 2, I have no clue whats going on there.

2 tests fail using python 3.4, linux:
- test_put_get_dataframe: expected array is wrong, semantically ok
- test_get_struct: expected array is wrong, semantically ok
