### PR TITLE
Python3 pass tests and libssl

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,7 +5,7 @@ Authors and Contributors
 Authors
 -------
 
-* Marek Rudnicki <marekrud@gmail.com>
+* Marek Rudnicki <marekrud@posteo.de>
 * Joakim Möller <joakim.moller@molflow.com>
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,12 +20,11 @@ Reporting Issues
 - At best, provide a small code snippet, that can run by itself and
   illustrates the problem.
 
-- Use either our `issue tracker`_ or our `mailing list`_.
+- Use the `issue tracker`_.
 
 
 .. _FAQ.rst: FAQ.rst
 .. _issue tracker: https://github.com/mrkrd/matlab_wrapper/issues
-.. _mailing list: matlab_wrapper@googlegroups.com
 
 
 
@@ -43,7 +42,7 @@ Contributing new Code
   implemented), TODO (some work has been started) or no status (not
   started).  The items often contain some intended implementation
   details and remarks.  You can also request more details through our
-  mailing list at matlab_wrapper@googlegroups.com.
+  issue tracker.
 
 - Coding style is mostly PEP8 compliant and The Zen of Python is your
   friend::

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -7,10 +7,32 @@ Error: Unknown MATLAB location?
 
 *matlab_wrapper* is unable to locate your MATLAB installation.
 
-TODO: explain how to fix it
+There are several ways to fix it:
 
-At the moment, you can check the documentation of the MatlabSession
-class (``matlab_root`` parameter).
+1. Include a path to the matlab executable in your PATH environment
+   variable.  You should be able to type ``matlab`` in your terminal
+   prompt and start MATLAB.  *matlab_wrapper* will try to locate the
+   libraries based on the location of the ``matlab`` executable file.
+   For example, put in your start-up files (.profile)::
+
+     export PATH=$PATH:/opt/MATLAB_R2014a/bin
+
+2. Set the environment variable MATLABROOT to the main MALTAB
+   directory, which can be found in MATLAB by typing::
+
+     matlabroot
+
+   Next, type in the shell or your profile file::
+
+     MATLABROOT=/opt/MATLAB/R2014b
+
+3. You can also set MATLAB's root directory in the ``MatlabSession``
+   constructor.  The disadvantage is that your script will not be
+   portable, e.g.::
+
+     matlab = matlab_wrapper.MatlabSession(matlab_root="/opt/MATLAB/R2014b")
+
+   See the documentation of ``MatlabSession`` for more details.
 
 
 

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -80,7 +80,14 @@ Is there alternative software?
 
 Yes.  Here's a little compilation:
 
-(last updated on June 17, 2014)
+(last updated on April 18, 2015)
+
+
+- `MATLAB Engine for Python`_
+
+  - official package from Mathworks
+  - supports new versions of Python (2.7, 3.3, and 3.4)
+  - ships with MATLAB 2015a
 
 - pymatlab_
 
@@ -114,6 +121,7 @@ There is a nice overview of the `available packages`_ at
 StackOverflow.
 
 
+.. _`MATLAB Engine for Python`: http://mathworks.com/help/matlab/matlab-engine-for-python.html
 .. _pymatlab: http://pymatlab.sourceforge.net/
 .. _mlabwrap: http://mlabwrap.sourceforge.net/
 .. _mlab: https://github.com/ewiger/mlab

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -106,7 +106,6 @@ Yes.  Here's a little compilation:
 
   - actively developed (good)
   - client-server architecture with ZeroMQ and JSON, complex (ugly)
-  - missing basic functions, there's no ``put`` (bad)
   - nice IPython Notebook support (good)
 
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,8 +1,8 @@
 matlab_wrapper -- history of user-visible changes
 =================================================
 
-Changes in version NEXT
------------------------
+Changes in version 0.9.7
+------------------------
 
 + Check if Python and MATLAB architectures match
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,12 @@
 matlab_wrapper -- history of user-visible changes
 =================================================
 
+Changes in version 0.9.8
+------------------------
+
++ Fix problem with cells (#19)
+
+
 Changes in version 0.9.7
 ------------------------
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,7 +4,7 @@ matlab_wrapper -- history of user-visible changes
 Changes in version 0.9.8
 ------------------------
 
-+ Fix problem with cells (#19)
++ Fix a problem with cells (#19)
 
 
 Changes in version 0.9.7

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,6 @@ scripts and an interactive shell.  MATLAB session is started in the
 background and appears as a regular Python module.
 
 **Warning**: *matlab_wrapper* is maintained, but not actively developed.
-Consider using the official `MATLAB Engine for Python`_, forking the
-repository, or using alternatives mentioned in the FAQ_.
-
-.. _`MATLAB Engine for Python`: http://mathworks.com/help/matlab/matlab-engine-for-python.html
 
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,11 @@ matlab_wrapper
 scripts and an interactive shell.  MATLAB session is started in the
 background and appears as a regular Python module.
 
+Warning: *matlab_wrapper* is maintained, but not actively developed.
+Consider using the official `MATLAB Engine for Python`_, forking the
+repository, or using alternatives mentioned in the FAQ_.
+
+_`MATLAB Engine for Python`: http://mathworks.com/help/matlab/matlab-engine-for-python.html
 
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Installation
 
 First, make sure that you have the following components installed:
 
-- Python (2.7, no Python 3 support yet)
+- Python 2.7
 - MATLAB (various versions)
 - Numpy
 

--- a/README.rst
+++ b/README.rst
@@ -93,10 +93,10 @@ Check our CONTRIBUTING_ guidelines.
 Support
 -------
 
-If you are having issues, please let us know.  We have a mailing list
-located at: matlab_wrapper@googlegroups.com
-
-Before reporting an issue, check FAQ_ and CONTRIBUTING_.
+If you are having issues, please let us know through the issue
+tracker: https://github.com/mrkrd/matlab_wrapper/issues.  Please avoid
+duplicates by searching previous issues, checking FAQ_ and
+CONTRIBUTING_.
 
 .. _FAQ: FAQ.rst
 .. _CONTRIBUTING: CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ MATLAB is a registered trademark of `The MathWorks, Inc`_.
 Citing
 ------
 
-Please cite this software when using in your research (click on the
+Please cite this software when using it in your research (click on the
 link for a full reference):
 
 .. image:: https://zenodo.org/badge/24233/mrkrd/matlab_wrapper.svg

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Warning: *matlab_wrapper* is maintained, but not actively developed.
 Consider using the official `MATLAB Engine for Python`_, forking the
 repository, or using alternatives mentioned in the FAQ_.
 
-_`MATLAB Engine for Python`: http://mathworks.com/help/matlab/matlab-engine-for-python.html
+.. _`MATLAB Engine for Python`: http://mathworks.com/help/matlab/matlab-engine-for-python.html
 
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ matlab_wrapper
 scripts and an interactive shell.  MATLAB session is started in the
 background and appears as a regular Python module.
 
-Warning: *matlab_wrapper* is maintained, but not actively developed.
+**Warning**: *matlab_wrapper* is maintained, but not actively developed.
 Consider using the official `MATLAB Engine for Python`_, forking the
 repository, or using alternatives mentioned in the FAQ_.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 matlab_wrapper
 ==============
 
+.. image:: https://zenodo.org/badge/24233/mrkrd/matlab_wrapper.svg
+   :target: https://zenodo.org/badge/latestdoi/24233/mrkrd/matlab_wrapper
+
 *matlab_wrapper* allows you to use MATLAB directly from your Python
 scripts and an interactive shell.  MATLAB session is started in the
 background and appears as a regular Python module.
@@ -108,6 +111,16 @@ MATLAB is a registered trademark of `The MathWorks, Inc`_.
 
 .. _pymatlab: http://pymatlab.sourceforge.net/
 .. _`The MathWorks, Inc`: http://www.mathworks.com/
+
+
+Citing
+------
+
+Please cite this software when using in your research (click on the
+link for a full reference):
+
+.. image:: https://zenodo.org/badge/24233/mrkrd/matlab_wrapper.svg
+   :target: https://zenodo.org/badge/latestdoi/24233/mrkrd/matlab_wrapper
 
 
 

--- a/TODO.org
+++ b/TODO.org
@@ -26,7 +26,7 @@
    - matlab_root (modify PATH, ln -s)
    - /bin/csh
 
-
+<2015-05-10 Sun 21:32>
 
 * Spread the word
 

--- a/TODO.org
+++ b/TODO.org
@@ -26,8 +26,6 @@
    - matlab_root (modify PATH, ln -s)
    - /bin/csh
 
-<2015-05-10 Sun 21:32>
-
 * Spread the word
 
 ** Show HN
@@ -78,7 +76,6 @@ matlab = matlab_wrapper.MatlabSession(auto_int_conversion=True)
   - check the standard library for the best kill/terminate functions
 
 
-<2014-08-14 Thu>
 
 MATLAB is unresponsive during execution of svd().  I did not find a
 way to reasonably kill the process (in destructor), because it hangs
@@ -160,18 +157,15 @@ OSError: /nfs/system/opt/MATLAB/R2014b/bin/glnxa64/libicuio.so.52: undefined sym
 
 https://groups.google.com/forum/#!topic/matlab_wrapper/wAp6veM6xgY
 
-<2015-04-18 Sat 19:41>
 
 Numpy indexing comes form C.
 
 In carr[i][j][k], k iterates the most inner row arrays.
 
-<2015-04-18 Sat 20:16>
 
 arr.ravel('K') flattens array in the order the elements occur in the
 memory.
 
-<2015-04-18 Sat 21:06>
 
 matlab_wrapper has to take into account inverse indexing:
 

--- a/TODO.org
+++ b/TODO.org
@@ -189,6 +189,13 @@ ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.si
 * TODO Conversion of a struct (#18)
 
 https://github.com/mrkrd/matlab_wrapper/issues/18
+
+[[notmuch:id:mrkrd/matlab_wrapper/issues/18/274494320@github.com]]
+
+- backward compatibility is super important
+- possible solution is to disable squeeze'ing in a backward compatible
+  way, e.g., MatlabSession(squeeze=False)
+
 * DONE Dimension of cellarrays (#19)
   CLOSED: [2017-01-24 Tue 14:03]
 

--- a/TODO.org
+++ b/TODO.org
@@ -4,7 +4,7 @@
 
 * IPython notebook support
 
-* TODO Documentation
+* DONE Documentation
 
 ** DONE Apply guidelines from writethedocs.org
 

--- a/TODO.org
+++ b/TODO.org
@@ -189,6 +189,9 @@ ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.si
 * TODO Conversion of a struct (#18)
 
 https://github.com/mrkrd/matlab_wrapper/issues/18
-* TODO Dimension of cellarrays (#19)
+* DONE Dimension of cellarrays (#19)
+  CLOSED: [2017-01-24 Tue 14:03]
 
 https://github.com/mrkrd/matlab_wrapper/issues/19
+
+fixed by PR #20

--- a/TODO.org
+++ b/TODO.org
@@ -185,3 +185,4 @@ as well as row vs column of the inner most arrays:
 
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
 ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz
+* TODO Create DOI for referencing

--- a/TODO.org
+++ b/TODO.org
@@ -2,8 +2,8 @@
 #+AUTHOR: Marek Rudnicki
 #+CATEGORY: matlab_wrap
 
-* MAYBE IPython notebook support
-  CLOSED: [2016-08-21 Sun 16:39]
+* CANCELED IPython notebook support
+  CLOSED: [2017-03-02 Thu 18:02]
 * DONE Documentation
 
 ** DONE Apply guidelines from writethedocs.org
@@ -39,7 +39,15 @@
 
 https://groups.google.com/forum/#!forum/comp.soft-sys.matlab
 
-* TODO Python 3 support
+* CANCELED Python 3 support
+  CLOSED: [2017-03-02 Thu 19:36]
+
+Better make a new library for Python 3 with the following properties:
+
+  - name: matlab_wrapper3 (?)
+  - don't squeeze values from Matlab
+  - assure proper indexing
+    https://groups.google.com/forum/#!topic/matlab_wrapper/wAp6veM6xgY
 
 ** Review PR #7 from David
 
@@ -159,7 +167,8 @@ Eventually put in FAQ.
 
 OSError: /nfs/system/opt/MATLAB/R2014b/bin/glnxa64/libicuio.so.52: undefined symbol: _ZN6icu_5213UnicodeString9doReplaceEiiPKDsii
 
-* TODO Investigate indexing in Numpy and MATLAB
+* DONE Investigate indexing in Numpy and MATLAB
+  CLOSED: [2017-03-02 Thu 18:04]
 
 https://groups.google.com/forum/#!topic/matlab_wrapper/wAp6veM6xgY
 
@@ -181,7 +190,7 @@ as well as row vs column of the inner most arrays:
 
  [i][j][k][l] <=> [k][l][j][i]
 
-* TODO Test string parameters (path) to a function (#15)
+* TODO [#C] Test string parameters (path) to a function (#15)
 
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
 ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz

--- a/TODO.org
+++ b/TODO.org
@@ -186,3 +186,9 @@ as well as row vs column of the inner most arrays:
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
 ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz
 * TODO Create DOI for referencing
+* TODO Conversion of a struct (#18)
+
+https://github.com/mrkrd/matlab_wrapper/issues/18
+* TODO Dimension of cellarrays (#19)
+
+https://github.com/mrkrd/matlab_wrapper/issues/19

--- a/TODO.org
+++ b/TODO.org
@@ -174,3 +174,4 @@ matlab_wrapper has to take into account inverse indexing:
 as well as row vs column of the inner most arrays:
 
  [i][j][k][l] <=> [k][l][j][i]
+* Test string parameters (path) to a function (#15)

--- a/TODO.org
+++ b/TODO.org
@@ -21,7 +21,7 @@
    - py.test
 
 
-** TODO FAQ
+** DONE FAQ
 
    - matlab_root (modify PATH, ln -s)
    - /bin/csh

--- a/TODO.org
+++ b/TODO.org
@@ -54,7 +54,10 @@ https://github.com/mrkrd/matlab_wrapper/pull/7
   - check mlabwrap
 
 
-* TODO Auto-convert int to float in matlab.put()
+* CANCELED Auto-convert int to float in matlab.put()
+  CLOSED: [2016-07-26 Tue 12:46]
+
+Canceled: “Explicit is better than implicit”
 
 The problem is that in MATLAB this conversion is implicit and writing
 e.g.
@@ -130,7 +133,10 @@ Issue #6 by Jeremy Moreau
 
 matlab_wrapper@googlegroups.com
 
-* TODO Investigate `undefined symbol' error
+* CANCELED Investigate `undefined symbol' error
+  CLOSED: [2016-07-26 Tue 12:47]
+
+Canceled: not able to reproduce.
 
 Might have something to do with matplotlib.
 
@@ -173,6 +179,7 @@ matlab_wrapper has to take into account inverse indexing:
 as well as row vs column of the inner most arrays:
 
  [i][j][k][l] <=> [k][l][j][i]
+
 * TODO Test string parameters (path) to a function (#15)
 
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m

--- a/TODO.org
+++ b/TODO.org
@@ -155,3 +155,28 @@ Eventually put in FAQ.
     367             self._handle = handle
 
 OSError: /nfs/system/opt/MATLAB/R2014b/bin/glnxa64/libicuio.so.52: undefined symbol: _ZN6icu_5213UnicodeString9doReplaceEiiPKDsii
+
+* TODO Investigate indexing in Numpy and MATLAB
+
+https://groups.google.com/forum/#!topic/matlab_wrapper/wAp6veM6xgY
+
+<2015-04-18 Sat 19:41>
+
+Numpy indexing comes form C.
+
+In carr[i][j][k], k iterates the most inner row arrays.
+
+<2015-04-18 Sat 20:16>
+
+arr.ravel('K') flattens array in the order the elements occur in the
+memory.
+
+<2015-04-18 Sat 21:06>
+
+matlab_wrapper has to take into account inverse indexing:
+
+ [i][j][k][l] <=> [l][k][j][i]
+
+as well as row vs column of the inner most arrays:
+
+ [i][j][k][l] <=> [k][l][j][i]

--- a/TODO.org
+++ b/TODO.org
@@ -175,3 +175,6 @@ as well as row vs column of the inner most arrays:
 
  [i][j][k][l] <=> [k][l][j][i]
 * Test string parameters (path) to a function (#15)
+
+ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
+ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz

--- a/TODO.org
+++ b/TODO.org
@@ -194,7 +194,11 @@ as well as row vs column of the inner most arrays:
 
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
 ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz
-* TODO Create DOI for referencing
+* DONE Create DOI for referencing
+  CLOSED: [2017-03-04 Sat 17:59]
+
+https://zenodo.org/badge/latestdoi/24233/mrkrd/matlab_wrapper
+
 * TODO Conversion of a struct (#18)
 
 https://github.com/mrkrd/matlab_wrapper/issues/18

--- a/TODO.org
+++ b/TODO.org
@@ -2,7 +2,8 @@
 #+AUTHOR: Marek Rudnicki
 #+CATEGORY: matlab_wrap
 
-* TODO IPython notebook support
+* MAYBE IPython notebook support
+  CLOSED: [2016-08-21 Sun 16:39]
 * DONE Documentation
 
 ** DONE Apply guidelines from writethedocs.org

--- a/TODO.org
+++ b/TODO.org
@@ -2,8 +2,7 @@
 #+AUTHOR: Marek Rudnicki
 #+CATEGORY: matlab_wrap
 
-* IPython notebook support
-
+* TODO IPython notebook support
 * DONE Documentation
 
 ** DONE Apply guidelines from writethedocs.org
@@ -26,7 +25,7 @@
    - matlab_root (modify PATH, ln -s)
    - /bin/csh
 
-* Spread the word
+* CANCELED Spread the word
 
 ** Show HN
 
@@ -46,7 +45,7 @@ https://groups.google.com/forum/#!forum/comp.soft-sys.matlab
 https://github.com/mrkrd/matlab_wrapper/pull/7
 
 
-* Auto-detect the number of output arguments (nout)
+* TODO Auto-detect the number of output arguments (nout)
 
   - check get_nout() from oct2py:
 
@@ -55,7 +54,7 @@ https://github.com/mrkrd/matlab_wrapper/pull/7
   - check mlabwrap
 
 
-* Auto-convert int to float in matlab.put()
+* TODO Auto-convert int to float in matlab.put()
 
 The problem is that in MATLAB this conversion is implicit and writing
 e.g.
@@ -125,13 +124,13 @@ Python is not correct.
 
 Issue #6 by Jeremy Moreau
 
-* Explicit warning when using Python 3
+* TODO Explicit warning when using Python 3
 
 * DONE Setup a mailing list
 
 matlab_wrapper@googlegroups.com
 
-* Investigate `undefined symbol' error
+* TODO Investigate `undefined symbol' error
 
 Might have something to do with matplotlib.
 
@@ -174,7 +173,7 @@ matlab_wrapper has to take into account inverse indexing:
 as well as row vs column of the inner most arrays:
 
  [i][j][k][l] <=> [k][l][j][i]
-* Test string parameters (path) to a function (#15)
+* TODO Test string parameters (path) to a function (#15)
 
 ftp://ftp.scp.byu.edu/pub/software/matlab/loadsir.m
 ftp://ftp.scp.byu.edu/data/qscat/1999/sir/queh/SAm/201/a/queh-a-SAm99-201-204.sir.gz

--- a/examples/eval_m_file.py
+++ b/examples/eval_m_file.py
@@ -7,11 +7,6 @@ located in my_script.m
 from __future__ import division, print_function, absolute_import
 from __future__ import unicode_literals
 
-__author__ = "Marek Rudnicki"
-__copyright__ = "Copyright 2014, Marek Rudnicki"
-__license__ = "GPLv3+"
-
-
 import matlab_wrapper
 
 

--- a/examples/eval_m_file.py
+++ b/examples/eval_m_file.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+"""Evaluate m-file and collect the results.
+
+"""
+from __future__ import division, print_function, absolute_import
+from __future__ import unicode_literals
+
+__author__ = "Marek Rudnicki"
+__copyright__ = "Copyright 2014, Marek Rudnicki"
+__license__ = "GPLv3+"
+
+
+import matlab_wrapper
+
+
+def main():
+    matlab = matlab_wrapper.MatlabSession()
+
+    matlab.put('x', 2.)
+    matlab.eval('my_script')
+    y = matlab.get('y')
+
+    print("And the winner is:", y)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/eval_m_file.py
+++ b/examples/eval_m_file.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-"""Evaluate m-file and collect the results.
+"""Evaluate m-file and collect the results.  A simple MATLAB script is
+located in my_script.m
 
 """
 from __future__ import division, print_function, absolute_import

--- a/examples/fir_filter.py
+++ b/examples/fir_filter.py
@@ -8,11 +8,6 @@ documentation.
 from __future__ import division, print_function, absolute_import
 from __future__ import unicode_literals
 
-__author__ = "Marek Rudnicki"
-__copyright__ = "Copyright 2014, Marek Rudnicki"
-__license__ = "GPLv3+"
-
-
 import numpy as np
 import matlab_wrapper
 

--- a/examples/my_script.m
+++ b/examples/my_script.m
@@ -1,0 +1,4 @@
+
+                                % Basic MATLAB script
+
+y = x * 2;

--- a/examples/my_script.m
+++ b/examples/my_script.m
@@ -1,4 +1,7 @@
 
                                 % Basic MATLAB script
 
+
+pause(3);
+
 y = x * 2;

--- a/examples/playground/sandbox.py
+++ b/examples/playground/sandbox.py
@@ -7,8 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
 import numpy as np
 
 import matlab_wrapper

--- a/examples/playground/sandbox_cells.py
+++ b/examples/playground/sandbox_cells.py
@@ -7,8 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
 import numpy as np
 
 import matlab_wrapper

--- a/examples/playground/sandbox_struct.py
+++ b/examples/playground/sandbox_struct.py
@@ -7,8 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
 import numpy as np
 
 import matlab_wrapper

--- a/examples/print_version.py
+++ b/examples/print_version.py
@@ -7,11 +7,6 @@
 from __future__ import division, print_function, absolute_import
 from __future__ import unicode_literals
 
-__author__ = "Marek Rudnicki"
-__copyright__ = "Copyright 2014, Marek Rudnicki"
-__license__ = "GPLv3+"
-
-
 import matlab_wrapper
 
 

--- a/examples/random_plot.py
+++ b/examples/random_plot.py
@@ -7,8 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
 import numpy as np
 
 import matlab_wrapper

--- a/matlab_wrapper/__init__.py
+++ b/matlab_wrapper/__init__.py
@@ -21,6 +21,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 
 from matlab_wrapper.matlab_session import MatlabSession

--- a/matlab_wrapper/__init__.py
+++ b/matlab_wrapper/__init__.py
@@ -21,11 +21,6 @@
 
 from __future__ import division, print_function, absolute_import
 
-__version__ = "0.9.6"
-
-__author__ = "Marek Rudnicki"
-__copyright__ = "Copyright 2014-2015, Marek Rudnicki"
-__license__ = "GPLv3+"
-
+__version__ = "0.9.7"
 
 from matlab_wrapper.matlab_session import MatlabSession

--- a/matlab_wrapper/matlab_session.py
+++ b/matlab_wrapper/matlab_session.py
@@ -597,19 +597,16 @@ def mxarray_to_ndarray(libmx, pm):
 
 
     elif class_name == 'cell':
-        out = []
+        out = np.empty(numelems, dtype='O')
         for i in range(numelems):
             cell = libmx.mxGetCell(pm, i)
 
             if bool(cell):
-                o = mxarray_to_ndarray(libmx, cell)
+                out[i] = mxarray_to_ndarray(libmx, cell)
             else:
                 ### uninitialized cell
-                o = None
+                out[i] = None
 
-            out.append(o)
-
-        out = np.array(out, dtype='O')
         out = out.reshape(dims[:ndims], order='F')
         out = out.squeeze()
 

--- a/matlab_wrapper/matlab_session.py
+++ b/matlab_wrapper/matlab_session.py
@@ -20,7 +20,6 @@
 
 # Python 2.x compability
 from __future__ import print_function, division, absolute_import
-from __future__ import unicode_literals
 
 import six
 from six import string_types
@@ -44,6 +43,7 @@ import weakref
 import collections
 
 import ctypes
+import ctypes.util
 from ctypes import c_char_p, POINTER, c_size_t, c_bool, c_void_p, c_int
 
 from matlab_wrapper.typeconv import dtype_to_mat
@@ -293,11 +293,14 @@ def load_engine_and_libs(matlab_root, options):
 
     system = platform.system()
 
+    open_libssl = ctypes.CDLL(ctypes.util.find_library('ssl'))
+
     if system == 'Linux':
         if bits == '64bit':
             lib_dir = join(matlab_root, "bin", "glnxa64")
         else:
             lib_dir = join(matlab_root, "bin", "glnx86")
+
 
         check_python_matlab_architecture(bits, lib_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as file:
 
 setup(
     name = "matlab_wrapper",
-    version = "0.9.7",
+    version = "0.9.8",
     author = "Marek Rudnicki",
     author_email = "marekrud@posteo.de",
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as file:
 
 setup(
     name = "matlab_wrapper",
-    version = "0.9.6",
+    version = "0.9.7",
     author = "Marek Rudnicki",
     author_email = "marekrud@posteo.de",
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name = "matlab_wrapper",
     version = "0.9.6",
     author = "Marek Rudnicki",
-    author_email = "marekrud@gmail.com",
+    author_email = "marekrud@posteo.de",
 
     description = "MATLAB wrapper for Python",
     license = "GPLv3",

--- a/tests/leak_loops/putget_loop.py
+++ b/tests/leak_loops/putget_loop.py
@@ -7,9 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
-
 import numpy as np
 
 import matlab_wrapper

--- a/tests/leak_loops/restart_loop.py
+++ b/tests/leak_loops/restart_loop.py
@@ -7,9 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
-
 import matlab_wrapper
 import psutil
 

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -7,8 +7,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-__author__ = "Marek Rudnicki"
-
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import pandas as pd

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -530,3 +530,12 @@ def test_put_object(matlab):
 
     with pytest.raises(NotImplementedError):
         matlab.put('foo', object())
+
+
+def test_cell_dimension(matlab):
+    command = """
+    cellNumEqualDims = { zeros(3,3); ones(3,3); rand(3,3) };
+    """
+    matlab.eval(command)
+    cellNumEqualDims = matlab.get('cellNumEqualDims')
+    assert(cellNumEqualDims.shape == (3,))

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -6,7 +6,6 @@
 """
 
 from __future__ import division, absolute_import, print_function
-
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import pandas as pd
@@ -373,8 +372,8 @@ def test_get_struct(matlab):
     s = matlab.get('s')
 
     desired = np.array([
-        (1, 'a'),
-        (2*1j, 'b')
+        (1, u'a'),
+        (2*1j, u'b')
     ], dtype=[('x', np.complex_, 1), ('y', six.text_type, 1)])
 
     assert_equal(s, desired)
@@ -393,7 +392,7 @@ def test_get_uninitialized_struct(matlab):
 
     desired = np.array([
         [(1, None), (None, None)],
-        [(None, None), (2, 'a')]
+        [(None, None), (2, u'a')]
     ], dtype=[('x', 'O'), ('y', 'O')])
 
     assert_equal(s, desired)
@@ -413,8 +412,8 @@ def test_get_empty_struct(matlab):
 def test_put_struct(matlab):
 
     a = np.rec.fromrecords([
-        (1, 'a', 1.),
-        (2, 'bb', 2.),
+        (1, u'a', 1.),
+        (2, u'bb', 2.),
     ])
 
     matlab.put('a', a)
@@ -441,8 +440,8 @@ def test_put_struct(matlab):
 def test_put_get_struct(matlab):
 
     a = np.rec.fromrecords([
-        (1, 'a', 1.),
-        (2, 'bb', 2.),
+        (1, u'a', 1.),
+        (2, u'bb', 2.),
     ])
 
     matlab.put('a', a)

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -398,7 +398,7 @@ def test_get_struct(matlab):
     desired = np.array([
         (1, 'a'),
         (2*1j, 'b')
-    ], dtype=[('x', np.complex_), ('y', six.text_type)])
+    ], dtype=[('x', np.complex_, 1), ('y', six.text_type, 1)])
 
     assert_equal(s, desired)
 
@@ -508,7 +508,7 @@ def test_put_get_dataframe(matlab):
     desired = np.array([
         (0, 1.0, 2, 'asdf'),
         (1, 1.1, 4, 'marek')
-    ], dtype=[('index', '<i8'), ('a', '<f8'), ('b', '<i8'), ('c', six.text_type)])
+    ], dtype=[('index', '<i8'), ('a', '<f8'), ('b', '<i8'), ('c', six.text_type, 5)])
 
     assert_equal(a, desired)
 

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -34,11 +34,9 @@ def matlab():
     return matlab
 
 
-
 def test_eval_ok(matlab):
     command = "a = ones(10)"
     matlab.eval(command)
-
 
 
 def test_eval_error(matlab):
@@ -65,7 +63,7 @@ def test_longscript(matlab):
 def test_get_numeric(matlab):
     for dtype in NUMERIC_DTYPES:
 
-        a = np.eye(4,5, dtype=dtype)
+        a = np.eye(4, 5, dtype=dtype)
         matlab.eval("b = eye(4,5, '{}')".format(dtype))
         b = matlab.get('b')
 
@@ -74,7 +72,7 @@ def test_get_numeric(matlab):
 
 
 def test_get_logical(matlab):
-    a = np.eye(4,5, dtype='bool')
+    a = np.eye(4, 5, dtype='bool')
     matlab.eval("b = eye(4,5) > 0")
     b = matlab.get('b')
 
@@ -84,7 +82,7 @@ def test_get_logical(matlab):
 
 def test_get_comples(matlab):
     for dtype in ('single', 'double'):
-        a = np.eye(4,5, dtype=dtype) + np.eye(4,5, dtype=dtype)*1j
+        a = np.eye(4, 5, dtype=dtype) + np.eye(4, 5, dtype=dtype)*1j
         matlab.eval("b = eye(4,5, '{0}') + eye(4,5, '{0}')*j".format(dtype))
         b = matlab.get('b')
 
@@ -106,10 +104,9 @@ def test_get_float(matlab):
     assert_equal(a, 1.)
 
 
-
 def test_put_numeric(matlab):
     for dtype in NUMERIC_DTYPES:
-        a = np.random.randn(2,3) * 10
+        a = np.random.randn(2, 3) * 10
         a = a.astype(dtype)
 
         matlab.put('a', a)
@@ -119,13 +116,13 @@ def test_put_numeric(matlab):
 
         numbers = output.split()[-6:]
         numbers = np.array(numbers, dtype=dtype)
-        numbers.shape = (2,3)
+        numbers.shape = (2, 3)
 
         assert_almost_equal(a, numbers, decimal=4)
 
 
 def test_put_logical(matlab):
-    a = np.random.randn(2,3)>0
+    a = np.random.randn(2, 3) > 0
 
     matlab.put('a', a)
     matlab.eval('a')
@@ -134,16 +131,14 @@ def test_put_logical(matlab):
 
     numbers = output.split()[-6:]
     numbers = np.array(numbers, dtype=int).astype('bool')
-    numbers.shape = (2,3)
+    numbers.shape = (2, 3)
 
     assert_equal(a, numbers)
 
 
-
-
 def test_put_complex128(matlab):
     for dtype in ('complex128', 'complex64'):
-        nums = np.linspace(0.1, 10, 6).reshape(2,3)
+        nums = np.linspace(0.1, 10, 6).reshape(2, 3)
 
         a = nums + nums*1j
         a = a.astype(dtype)
@@ -153,9 +148,12 @@ def test_put_complex128(matlab):
 
         output = matlab.output_buffer.split('\n')
 
-        assert_equal(output[3], '   0.1000 + 0.1000i   2.0800 + 2.0800i   4.0600 + 4.0600i')
-        assert_equal(output[4], '   6.0400 + 6.0400i   8.0200 + 8.0200i  10.0000 +10.0000i')
-
+        assert_equal(
+            output[3],
+            '   0.1000 + 0.1000i   2.0800 + 2.0800i   4.0600 + 4.0600i')
+        assert_equal(
+            output[4],
+            '   6.0400 + 6.0400i   8.0200 + 8.0200i  10.0000 +10.0000i')
 
 
 def test_put_string(matlab):
@@ -169,8 +167,6 @@ def test_put_string(matlab):
     assert_equal(s, "asdf")
 
 
-
-
 def test_put_unicode(matlab):
     matlab.put('s', u"Łódź")
     matlab.eval('s')
@@ -180,7 +176,6 @@ def test_put_unicode(matlab):
     s = output[-1]
 
     assert_equal(s, u"Łódź")
-
 
 
 def test_put_unicode_len(matlab):
@@ -195,8 +190,6 @@ def test_put_unicode_len(matlab):
     assert_equal(length, len(s))
 
 
-
-
 def test_put_float(matlab):
     matlab.put('a', 3.2)
     matlab.eval('a')
@@ -208,11 +201,9 @@ def test_put_float(matlab):
     assert_equal(a, 3.2)
 
 
-
-
 def test_put_get_numeric(matlab):
     for dtype in NUMERIC_DTYPES:
-        a = np.random.randn(3,2,4) * 10
+        a = np.random.randn(3, 2, 4) * 10
         a = a.astype(dtype)
 
         matlab.put('a', a)
@@ -222,9 +213,8 @@ def test_put_get_numeric(matlab):
         assert_equal(a, aa)
 
 
-
 def test_put_get_logical(matlab):
-    a = np.random.randn(3,2,4)>0
+    a = np.random.randn(3, 2, 4) > 0
 
     matlab.put('a', a)
     aa = matlab.get('a')
@@ -235,15 +225,14 @@ def test_put_get_logical(matlab):
 
 def test_put_get_complex(matlab):
     for datatype in ("complex64", "complex128"):
-        a = np.random.randn(2,4,3) + np.random.randn(2,4,3)*1j
+        a = np.random.randn(2, 4, 3) + np.random.randn(2, 4, 3)*1j
         a = a.astype(datatype)
 
-        matlab.put('a',a)
+        matlab.put('a', a)
         aa = matlab.get('a')
 
         assert_equal(a.dtype, aa.dtype)
         assert_equal(a, aa)
-
 
 
 def test_put_get_string(matlab):
@@ -253,7 +242,6 @@ def test_put_get_string(matlab):
     ss = matlab.get('s')
 
     assert_equal(s, ss)
-
 
 
 def test_workspace_func(matlab):
@@ -266,13 +254,12 @@ def test_workspace_func(matlab):
     assert_equal(y, ymatlab)
 
 
-
 def test_workspace_nout(matlab):
-    a = np.array([2,1,3])
+    a = np.array([2, 1, 3])
 
-    y,i = matlab.workspace.sort(a, nout=2)
+    y, i = matlab.workspace.sort(a, nout=2)
 
-    assert_equal(y, [1,2,3])
+    assert_equal(y, [1, 2, 3])
     assert_equal(i, a)
 
 
@@ -302,7 +289,7 @@ def test_get_cell(matlab):
     target = np.array(
         [
             [1., 2., 3.],
-            ['text', np.eye(2,3), np.array([11.,22.,33.], dtype='O')]
+            ['text', np.eye(2, 3), np.array([11., 22., 33.], dtype='O')]
         ],
         dtype='O'
     )
@@ -310,8 +297,8 @@ def test_get_cell(matlab):
     assert_equal(actual.shape, target.shape)
     assert_equal(actual.dtype, target.dtype)
 
-    for a,t in zip(actual.flatten(),target.flatten()):
-        assert_equal(a,t)
+    for a, t in zip(actual.flatten(), target.flatten()):
+        assert_equal(a, t)
 
 
 def test_get_uninitialized_cell(matlab):
@@ -327,23 +314,21 @@ def test_get_uninitialized_cell(matlab):
     assert_equal(actual.shape, target.shape)
     assert_equal(actual.dtype, target.dtype)
 
-    for a,t in zip(actual.flatten(),target.flatten()):
-        assert_equal(a,t)
-
+    for a, t in zip(actual.flatten(), target.flatten()):
+        assert_equal(a, t)
 
 
 def test_put_cell(matlab):
 
-    sub = np.array([3, 4.,'b'], dtype='O')
+    sub = np.array([3, 4., 'b'], dtype='O')
     c = np.array([
-        [1 , 'a'],
+        [1, 'a'],
         [2., sub]
     ], dtype='O')
 
-
     matlab.put('c', c)
 
-    ### check the main array
+    # check the main array
     matlab.eval('c')
 
     output = matlab.output_buffer.split('\n')
@@ -351,8 +336,7 @@ def test_put_cell(matlab):
     assert_equal(output[3], "    [1]    'a'       ")
     assert_equal(output[4], "    [2]    {1x3 cell}")
 
-
-    ### check the sub-array
+    # check the sub-array
     matlab.eval('c{2,2}')
 
     output = matlab.output_buffer.split('\n')
@@ -360,15 +344,12 @@ def test_put_cell(matlab):
     assert_equal(output[3], "    [3]    [4]    'b'")
 
 
-
-
-
 def test_put_get_cell(matlab):
 
     a = np.array(
         [
             [1., 2., 3.],
-            ['text', np.eye(2,3), np.array([11.,22.,33.], dtype='O')]
+            ['text', np.eye(2, 3), np.array([11., 22., 33.], dtype='O')]
         ],
         dtype='O'
     )
@@ -376,11 +357,8 @@ def test_put_get_cell(matlab):
     matlab.workspace.a = a
     aa = matlab.workspace.a
 
-    for el,elel in zip(a.flatten(),aa.flatten()):
-        assert_equal(el,elel)
-
-
-
+    for el, elel in zip(a.flatten(), aa.flatten()):
+        assert_equal(el, elel)
 
 
 def test_get_struct(matlab):
@@ -403,7 +381,6 @@ def test_get_struct(matlab):
     assert_equal(s, desired)
 
 
-
 def test_get_uninitialized_struct(matlab):
 
     matlab.eval("""
@@ -415,14 +392,12 @@ def test_get_uninitialized_struct(matlab):
 
     s = matlab.get('s')
 
-
     desired = np.array([
         [(1, None), (None, None)],
         [(None, None), (2, 'a')]
     ], dtype=[('x', 'O'), ('y', 'O')])
 
     assert_equal(s, desired)
-
 
 
 def test_get_empty_struct(matlab):
@@ -436,7 +411,6 @@ def test_get_empty_struct(matlab):
     assert_equal(s, desired)
 
 
-
 def test_put_struct(matlab):
 
     a = np.rec.fromrecords([
@@ -446,7 +420,7 @@ def test_put_struct(matlab):
 
     matlab.put('a', a)
 
-    ### 1st element
+    # 1st element
     matlab.eval('a(1)')
 
     output = matlab.output_buffer.split('\n')
@@ -455,8 +429,7 @@ def test_put_struct(matlab):
     assert_equal(output[4], "    f1: 'a'")
     assert_equal(output[5], "    f2: 1")
 
-
-    ### 2nd element
+    # 2nd element
     matlab.eval('a(2)')
 
     output = matlab.output_buffer.split('\n')
@@ -464,8 +437,6 @@ def test_put_struct(matlab):
     assert_equal(output[3], "    f0: 2")
     assert_equal(output[4], "    f1: 'bb'")
     assert_equal(output[5], "    f2: 2")
-
-
 
 
 def test_put_get_struct(matlab):
@@ -482,7 +453,6 @@ def test_put_get_struct(matlab):
     assert_equal(a, aa)
 
 
-
 def test_put_strings(matlab):
     s = ['asdf', 'a', 'BBB']
 
@@ -492,8 +462,6 @@ def test_put_strings(matlab):
     output = matlab.output_buffer.split('\n')
 
     assert_equal(output[3], "    'asdf'    'a'    'BBB'")
-
-
 
 
 def test_put_get_dataframe(matlab):
@@ -508,10 +476,13 @@ def test_put_get_dataframe(matlab):
     desired = np.array([
         (0, 1.0, 2, 'asdf'),
         (1, 1.1, 4, 'marek')
-    ], dtype=[('index', '<i8'), ('a', '<f8'), ('b', '<i8'), ('c', six.text_type, 5)])
+    ], dtype=[('index', '<i8'),
+              ('a', '<f8'),
+              ('b', '<i8'),
+              ('c', six.text_type, 5)]
+    )
 
     assert_equal(a, desired)
-
 
 
 def test_put_get_series(matlab):

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -6,7 +6,6 @@
 """
 
 from __future__ import division, absolute_import, print_function
-from __future__ import unicode_literals
 
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal


### PR DESCRIPTION
Hi,

Thanks for the good work!

Due to the data types of structured arrays, a few tests failed on the `python3` branch (at least after I merged with `master`). All tests now pass using Python 3.5.2 and Python 2.7.12, but for compatibility with Python 2, unicode strings have to be input as data to numpy arrays explicitly (```u''```). I can't seem to find an elegant solution because dtype field names can't be unicode in numpy (see [here](https://github.com/numpy/numpy/issues/2407l)).

Also, when first used with Matlab 9.0.0.341360 (R2016a), I got the error:
```OSError: /opt/MWmatlabR2016a/bin/glnxa64/libssl.so.1.0.0: undefined symbol: EVP_idea_cbc```
which occurs because Matlab 2016a is using an older version of `libssl.`. Unfortunately, I don't have permission to modify the system environment, so [one workaround](https://github.com/deeuu/matlab_wrapper/blob/python3/matlab_wrapper/matlab_session.py#L296) is to load the system's `libssl` prior to loading `libeng` and `libmg`.

Only tested on Ubuntu 16.04.2 LTS.

Cheers